### PR TITLE
refactor: rename test job to pest in workflow

### DIFF
--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  pest:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Renames the test job to pest in the GitHub Actions workflow file. 
This change improves clarity by aligning the job name with the 
testing framework used, making it easier for contributors to 
understand the purpose of the job.