### PR TITLE
feat: make menu leaner

### DIFF
--- a/src/Commands/OmakaseCommand.php
+++ b/src/Commands/OmakaseCommand.php
@@ -35,19 +35,9 @@ class OmakaseCommand extends Command
 
             $composerPackages = [
                 'require' => [
-                    'laravel/horizon' => [
-                        ['php', 'artisan', 'horizon:install'],
-                    ],
-                    'laravel/pulse' => [
-                        ['php', 'artisan', 'vendor:publish', '--tag=pulse-config'],
-                        ['php', 'artisan', 'vendor:publish', '--tag=pulse-dashboard'],
-                        ['php', 'artisan', 'vendor:publish', '--provider="Laravel\Pulse\PulseServiceProvider"'],
-                        ['php', 'artisan', 'migrate'],
-                    ],
                     'livewire/livewire' => [
                         ['php', 'artisan', 'livewire:publish', '--config'],
                     ],
-                    'spatie/laravel-sluggable',
                 ],
                 'require-dev' => [
                     'barryvdh/laravel-ide-helper',


### PR DESCRIPTION
This pull request modifies the `handle` method in the `OmakaseCommand` class to streamline the list of Composer packages and their associated commands. The most notable changes involve removing several Laravel-related packages and their setup commands from the `require` list.

### Streamlining Composer package setup:

* Removed `laravel/horizon` and its installation command from the `require` list.
* Removed `laravel/pulse` along with its configuration publishing, dashboard publishing, service provider publishing, and migration commands from the `require` list.
* Removed `spatie/laravel-sluggable` from the `require` list without any associated commands.