### PR TITLE
Fix copy-file logic

### DIFF
--- a/src/Commands/OmakaseCommand.php
+++ b/src/Commands/OmakaseCommand.php
@@ -178,14 +178,15 @@ class OmakaseCommand extends Command
                 $destDirname = dirname($destPathname);
                 $relativeDest = str_replace(base_path().'/', '', $destPathname);
 
-                if (File::exists($destPathname) && ! $this->option('force')) {
+                $fileExists = File::exists($destPathname);
+                if ($fileExists && ! $this->option('force')) {
                     $this->warn("skip {$relativeDest}");
 
                     continue;
                 }
 
                 $this->copyFile($filePathname, $destPathname, $destDirname);
-                $this->info(File::exists($destPathname) ? "override {$relativeDest}" : "new {$relativeDest}");
+                $this->info($fileExists ? "override {$relativeDest}" : "new {$relativeDest}");
             }
         } catch (\Exception $e) {
             $this->error($e->getMessage());
@@ -236,7 +237,7 @@ class OmakaseCommand extends Command
             throw new \Exception("Failed to read file: {$filePathname}");
         }
 
-        if (! file_put_contents($destPathname, $contents)) {
+        if (file_put_contents($destPathname, $contents) === false) {
             throw new \Exception("Failed to write file: {$destPathname}");
         }
 


### PR DESCRIPTION
## Summary
- fix boolean check when writing files to avoid exception on empty writes
- correctly report whether file was created or overridden when copying
- rename `$fileExists` variable for clarity

## Testing
- `php vendor/bin/pest` *(fails: command not found)*