### PR TITLE
Improve test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,13 +26,15 @@ This repository contains a Laravel package that installs a set of development to
 
 ## Running Tests
 
-Use PHP **8.2** or higher and run:
+Use PHP **8.2** or higher and run the following checks before committing:
 
 ```bash
 php vendor/bin/pest
+php vendor/bin/pint --test
+php vendor/bin/phpstan analyse
 ```
 
-This executes the test suite using Pest.
+These commands run the test suite, check code style and perform static analysis.
 
 ## Commit Guidelines
 

--- a/tests/Feature/Commands/OmakaseInternalsTest.php
+++ b/tests/Feature/Commands/OmakaseInternalsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use Bigpixelrocket\LaravelOmakase\Commands\OmakaseCommand;
+use Illuminate\Support\Facades\File;
+use Mockery;
+
+use function callProtectedMethod;
+use function Pest\Laravel\artisan;
+
+it('returns sorted file list from getDistFiles', function () {
+    $dir = sys_get_temp_dir().'/dist_'.uniqid();
+    File::ensureDirectoryExists("{$dir}/b");
+    File::ensureDirectoryExists("{$dir}/a");
+    file_put_contents("{$dir}/b/two.txt", '2');
+    file_put_contents("{$dir}/a/one.txt", '1');
+
+    $command = new OmakaseCommand;
+    $files = callProtectedMethod($command, 'getDistFiles', [$dir.'/']);
+
+    expect($files)->toBe([
+        "{$dir}/a/one.txt",
+        "{$dir}/b/two.txt",
+    ]);
+
+    File::deleteDirectory($dir);
+});
+
+it('creates directories when copying files', function () {
+    $dir = sys_get_temp_dir().'/copy_'.uniqid();
+    File::ensureDirectoryExists($dir);
+    $source = "{$dir}/src.txt";
+    $destDir = "{$dir}/nested";
+    $dest = "{$destDir}/dest.txt";
+    file_put_contents($source, 'abc');
+
+    $command = new OmakaseCommand;
+    callProtectedMethod($command, 'copyFile', [$source, $dest, $destDir]);
+
+    expect(File::exists($dest))->toBeTrue();
+    expect(file_get_contents($dest))->toBe('abc');
+
+    File::deleteDirectory($dir);
+});
+
+it('builds expected commands in installPackages', function () {
+    $command = Mockery::mock(OmakaseCommand::class)
+        ->shouldAllowMockingProtectedMethods()
+        ->makePartial();
+
+    $packages = [
+        'require' => [
+            'foo/bar',
+            'livewire/livewire' => [
+                ['php', 'artisan', 'livewire:publish', '--config'],
+            ],
+        ],
+        'require-dev' => [
+            'phpunit/phpunit',
+        ],
+    ];
+
+    $expectedRequire = [
+        ['composer', 'require', 'foo/bar', 'livewire/livewire'],
+        ['php', 'artisan', 'livewire:publish', '--config'],
+    ];
+
+    $expectedDev = [
+        ['composer', 'require', '--dev', 'phpunit/phpunit'],
+    ];
+
+    $command->shouldReceive('execCommands')->with($expectedRequire)->once()->andReturn(true);
+    $command->shouldReceive('execCommands')->with($expectedDev)->once()->andReturn(true);
+
+    $result = callProtectedMethod($command, 'installPackages', [$packages, ['composer', 'require'], 'require-dev', '--dev']);
+
+    expect($result)->toBeTrue();
+
+    $command->shouldHaveReceived('execCommands')->with($expectedRequire)->once();
+    $command->shouldHaveReceived('execCommands')->with($expectedDev)->once();
+});
+
+it('copies dist files respecting the force option', function () {
+    $base = sys_get_temp_dir().'/base_'.uniqid();
+    File::ensureDirectoryExists($base);
+
+    $app = app();
+    $original = $app->basePath();
+    $app->setBasePath($base);
+
+    try {
+        artisan(OmakaseCommand::class, ['--files' => true])->assertSuccessful();
+        expect(File::exists("{$base}/phpstan.neon"))->toBeTrue();
+        expect(File::exists("{$base}/pint.json"))->toBeTrue();
+
+        $originalContent = file_get_contents("{$base}/pint.json");
+        artisan(OmakaseCommand::class, ['--files' => true])->assertSuccessful();
+
+        file_put_contents("{$base}/pint.json", 'changed');
+        artisan(OmakaseCommand::class, ['--files' => true, '--force' => true])->assertSuccessful();
+        expect(file_get_contents("{$base}/pint.json"))->toBe($originalContent);
+    } finally {
+        $app->setBasePath($original);
+        File::deleteDirectory($base);
+    }
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -17,3 +17,15 @@ uses(Tests\TestCase::class)->in('Feature');
 expect()->extend('toBeOne', function ($value) {
     return expect($value)->toBe(1);
 });
+
+/**
+ * Call a protected method on an object using reflection.
+ */
+function callProtectedMethod(object $object, string $method, array $arguments = [])
+{
+    $reflection = new ReflectionClass($object);
+    $method = $reflection->getMethod($method);
+    $method->setAccessible(true);
+
+    return $method->invokeArgs($object, $arguments);
+}


### PR DESCRIPTION
## Summary
- document testing improvement plan
- expose helper for calling protected methods in tests
- add feature tests for command internals
- remove test plan document
- note Pint and PHPStan requirements in AGENTS guidelines

## Testing
- `php vendor/bin/pest`
- `php vendor/bin/pint --test`
- `php vendor/bin/phpstan analyse`
