### PR TITLE
chore(config): remove scaffold:workflows from deployer commands

### DIFF
--- a/config/composer-packages.php
+++ b/config/composer-packages.php
@@ -44,7 +44,6 @@ return [
                 ['vendor/bin/deployer', 'scaffold:crons'],
                 ['vendor/bin/deployer', 'scaffold:hooks'],
                 ['vendor/bin/deployer', 'scaffold:supervisors'],
-                ['vendor/bin/deployer', 'scaffold:workflows'],
             ],
             'command_options' => ['destination', 'force'],
         ],


### PR DESCRIPTION
## Summary

Remove the `scaffold:workflows` command from the deployer post-install sequence. This command is no longer needed in the installation flow.

## Changes

- Removed `scaffold:workflows` from the deployer installation commands in `config/composer-packages.php`