### PR TITLE
fix(composer): add -W flag for dependency resolution

### DIFF
--- a/src/Commands/MiseCommand.php
+++ b/src/Commands/MiseCommand.php
@@ -88,7 +88,7 @@ class MiseCommand extends BaseCommand
 
         $this->h1('Installing Composer Packages');
 
-        $this->runProcess(['composer', 'update', '--no-scripts']);
+        $this->runProcess(['composer', 'update', '-W', '--no-scripts']);
 
         $composerPackages = config('laravel-mise.composer-packages');
 
@@ -99,7 +99,7 @@ class MiseCommand extends BaseCommand
         }
 
         /** @var array<string, array<string|array<string, array<array<string>>|array<string, mixed>>>> $composerPackages */
-        $this->installPackages($composerPackages, ['composer', 'require', '--no-scripts'], 'require-dev', '--dev');
+        $this->installPackages($composerPackages, ['composer', 'require', '-W', '--no-scripts'], 'require-dev', '--dev');
 
         //
         // Trigger Deferred Composer Scripts

--- a/tests/Feature/Commands/MiseCommandTest.php
+++ b/tests/Feature/Commands/MiseCommandTest.php
@@ -37,7 +37,7 @@ describe('MiseCommand Feature Tests', function (): void {
             ->assertSuccessful();
 
         // ASSERT
-        $this->assertCommandRan('composer update --no-scripts');
+        $this->assertCommandRan('composer update -W --no-scripts');
         $this->assertCommandRan('composer dump-autoload');
         $this->assertCommandRan('composer run-script post-update-cmd');
     });
@@ -75,7 +75,7 @@ describe('MiseCommand Feature Tests', function (): void {
                 ->assertSuccessful();
 
             // ASSERT
-            $this->assertCommandRan('composer update --no-scripts');
+            $this->assertCommandRan('composer update -W --no-scripts');
         });
 
         it('skips confirmation when --yes flag provided', function (): void {
@@ -84,7 +84,7 @@ describe('MiseCommand Feature Tests', function (): void {
                 ->assertSuccessful();
 
             // ASSERT - commands ran without confirmation prompt
-            $this->assertCommandRan('composer update --no-scripts');
+            $this->assertCommandRan('composer update -W --no-scripts');
         });
     });
 
@@ -155,8 +155,8 @@ describe('MiseCommand Feature Tests', function (): void {
                 ->assertSuccessful();
 
             // ASSERT - composer update ran and subsequent commands still executed
-            $this->assertCommandRan('composer update --no-scripts');
-            $this->assertCommandRan('composer require --no-scripts');
+            $this->assertCommandRan('composer update -W --no-scripts');
+            $this->assertCommandRan('composer require -W --no-scripts');
         });
 
         it('continues when npm update fails (soft error)', function (): void {
@@ -196,7 +196,7 @@ describe('MiseCommand Feature Tests', function (): void {
                 ->assertSuccessful();
 
             // ASSERT
-            $this->assertCommandRan('composer update --no-scripts');
+            $this->assertCommandRan('composer update -W --no-scripts');
         });
 
     });


### PR DESCRIPTION
## Summary

Enable Composer's `--with-all-dependencies` flag in update and require commands to allow proper package upgrades/downgrades when resolving dependencies.

## Details

- Added `-W` flag to `composer update` command (line 91)
- Added `-W` flag to `composer require` command (line 102)
- Updated 6 test assertions to expect the new flag

Without this flag, Composer may fail to install packages when existing dependencies conflict with new version constraints. The `-W` flag enables flexible resolution, making package installation more reliable in real-world projects.

## Test Results

- ✅ Pint (code formatting)
- ✅ Rector (refactoring suggestions)
- ✅ PHPStan (static analysis)
- ✅ Tests (22 passed, 62 assertions)