### PR TITLE
feat(deployer): add --agent=claude to scaffold:ai command

### DIFF
--- a/config/composer-packages.php
+++ b/config/composer-packages.php
@@ -40,7 +40,7 @@ return [
         ],
         'loadinglucian/deployer-php' => [
             'commands' => [
-                ['vendor/bin/deployer', 'scaffold:ai'],
+                ['vendor/bin/deployer', 'scaffold:ai', '--agent=claude'],
                 ['vendor/bin/deployer', 'scaffold:crons'],
                 ['vendor/bin/deployer', 'scaffold:hooks'],
                 ['vendor/bin/deployer', 'scaffold:supervisors'],


### PR DESCRIPTION
## Summary

Add the `--agent=claude` parameter to the deployer `scaffold:ai` command in the composer packages configuration.

This ensures that when the scaffolding command runs during Laravel Mise installation, it automatically targets the `.claude/` directory without prompting for user interaction.

## Implementation

Modified `config/composer-packages.php` line 43:
- Before: `['vendor/bin/deployer', 'scaffold:ai']`
- After: `['vendor/bin/deployer', 'scaffold:ai', '--agent=claude']`

## Benefits

- Eliminates interactive prompts in automated installation environments
- Provides predictable behavior when running on CI/CD systems
- Maintains consistency with the Claude Code ecosystem